### PR TITLE
Experimenting with a bounded cache.

### DIFF
--- a/haxl.cabal
+++ b/haxl.cabal
@@ -39,7 +39,8 @@ library
     time == 1.4.*,
     unordered-containers == 0.2.*,
     vector == 0.10.*,
-    deepseq == 1.3.*
+    deepseq == 1.3.*,
+    LRUBoundedMap
 
   exposed-modules:
     Haxl.Core,


### PR DESCRIPTION
This commit uses an LRU bounded map from

https://github.com/blitzcode/lru-bounded-map

in order to test using Haxl with a bounded cache. While this removes the
function of the cache to ensure consistency, it allows to use Haxl with
a large number of requests that involve nontrivial amounts of data. With
the unbounded cache originally implemented in Haxl, we'd risk requiring
unbounded amounts of memory in that use case.